### PR TITLE
handle nil alias correctly in query builder

### DIFF
--- a/Sources/libAutoGraphCodeGen/OldQueryCodeGen.swift
+++ b/Sources/libAutoGraphCodeGen/OldQueryCodeGen.swift
@@ -174,7 +174,12 @@ extension Field {
     
     public func generateObjectQueryComponent(indentation: String) -> (queryComponent: String, requiredFragments: Set<FragmentName>) {
         let name = self.name.generateQueryComponent()
-        let alias = self.alias.generateQueryComponent()
+        let alias = {
+            // TODO: Possibly better solution is to not use a typealias, make Alias
+            // `Alias` is a typealias for `Name`, but `Alias?` as different semantics than `Name?`.
+            guard let alias = self.alias else { return "nil" }
+            return alias.generateQueryComponent()
+        }()
         let arguments = self.arguments.generateQueryComponent()
         let directives = self.directives.generateQueryComponent()
         let selectionSet = self.selectionSet!.generateQueryComponent(indentation: indentation)
@@ -183,7 +188,12 @@ extension Field {
     
     public func generateScalarQueryComponent() -> String {
         let name = self.name.generateQueryComponent()
-        let alias = self.alias.generateQueryComponent()
+        let alias = {
+            // TODO: Possibly better solution is to not use a typealias, make Alias
+            // `Alias` is a typealias for `Name`, but `Alias?` as different semantics than `Name?`.
+            guard let alias = self.alias else { return "nil" }
+            return alias.generateQueryComponent()
+        }()
         let arguments = self.arguments.generateQueryComponent()
         let directives = self.directives.generateQueryComponent()
         return Field.generateScalarQueryComponent(name: name, alias: alias, arguments: arguments, directives: directives)

--- a/Tests/Resources/poke-gql/Queries/Example.graphql
+++ b/Tests/Resources/poke-gql/Queries/Example.graphql
@@ -14,9 +14,10 @@ query ExamplePokemon(
       ability_id
       pokemon_v2_ability {
         name @specifiedBy
+        other_name: name @specifiedBy
         is_main_series
         pokemon_v2_abilityflavortexts_aggregate(order_by: $orderBy) {
-          aggregate {
+          agg: aggregate {
             count
           }
         }

--- a/Tests/libAutoGraphCodeGenTests/Products/anilist-gql/AniListGQLSchema.swift
+++ b/Tests/libAutoGraphCodeGenTests/Products/anilist-gql/AniListGQLSchema.swift
@@ -71,18 +71,18 @@ public struct ExampleAniListWithEnumFieldQuery: AutoGraphQLRequest {
     public var operation: AutoGraphQL.Operation {
         return AutoGraphQL.Operation(type: .query, name: "ExampleAniListWithEnumField", variableDefinitions: nil, directives: nil, selectionSet: [
             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-            Selection.field(name: "Page", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "Page", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "media", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                Selection.field(name: "media", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "type", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "siteUrl", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "title", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                    Selection.field(name: "type", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "siteUrl", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "title", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                         Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                        Selection.field(name: "english", alias: "", arguments: nil, directives: nil, type: .scalar),
-                        Selection.field(name: "native", alias: "", arguments: nil, directives: nil, type: .scalar)
+                        Selection.field(name: "english", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                        Selection.field(name: "native", alias: nil, arguments: nil, directives: nil, type: .scalar)
                     ])),
-                    Selection.field(name: "description", alias: "", arguments: nil, directives: nil, type: .scalar)
+                    Selection.field(name: "description", alias: nil, arguments: nil, directives: nil, type: .scalar)
                 ]))
             ]))
         ])

--- a/Tests/libAutoGraphCodeGenTests/Products/poke-gql/PokeGQLSchema.swift
+++ b/Tests/libAutoGraphCodeGenTests/Products/poke-gql/PokeGQLSchema.swift
@@ -33,24 +33,25 @@ public struct ExamplePokemonQuery: AutoGraphQLRequest {
     public var operation: AutoGraphQL.Operation {
         return AutoGraphQL.Operation(type: .query, name: "ExamplePokemon", variableDefinitions: [try! AnyVariableDefinition(name: "pokemonV2AbilityByPkId", typeName: .nonNull(.scalar(.int)), defaultValue: nil)], directives: nil, selectionSet: [
             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-            Selection.field(name: "pokemon_v2_ability_by_pk", alias: "", arguments: ["id" : Variable(name: "pokemonV2AbilityByPkId")], directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "pokemon_v2_ability_by_pk", alias: nil, arguments: ["id" : Variable(name: "pokemonV2AbilityByPkId")], directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "generation_id", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "id", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "is_main_series", alias: "", arguments: nil, directives: [Directive(name: "skip", arguments: ["if" : false])], type: .scalar),
-                Selection.field(name: "name", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "pokemon_v2_abilitychanges", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                Selection.field(name: "generation_id", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "id", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "is_main_series", alias: nil, arguments: nil, directives: [Directive(name: "skip", arguments: ["if" : false])], type: .scalar),
+                Selection.field(name: "name", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "pokemon_v2_abilitychanges", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "ability_id", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "pokemon_v2_ability", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                    Selection.field(name: "ability_id", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "pokemon_v2_ability", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                         Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                        Selection.field(name: "name", alias: "", arguments: nil, directives: [Directive(name: "specifiedBy", arguments: nil)], type: .scalar),
-                        Selection.field(name: "is_main_series", alias: "", arguments: nil, directives: nil, type: .scalar),
-                        Selection.field(name: "pokemon_v2_abilityflavortexts_aggregate", alias: "", arguments: ["order_by" : Variable(name: "orderBy")], directives: nil, type: .object(selectionSet: [
+                        Selection.field(name: "name", alias: nil, arguments: nil, directives: [Directive(name: "specifiedBy", arguments: nil)], type: .scalar),
+                        Selection.field(name: "name", alias: "other_name", arguments: nil, directives: [Directive(name: "specifiedBy", arguments: nil)], type: .scalar),
+                        Selection.field(name: "is_main_series", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                        Selection.field(name: "pokemon_v2_abilityflavortexts_aggregate", alias: nil, arguments: ["order_by" : Variable(name: "orderBy")], directives: nil, type: .object(selectionSet: [
                             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                            Selection.field(name: "aggregate", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                            Selection.field(name: "aggregate", alias: "agg", arguments: nil, directives: nil, type: .object(selectionSet: [
                                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "count", alias: "", arguments: nil, directives: nil, type: .scalar)
+                                Selection.field(name: "count", alias: nil, arguments: nil, directives: nil, type: .scalar)
                             ]))
                         ]))
                     ]))
@@ -120,10 +121,11 @@ public struct ExamplePokemonQuery: AutoGraphQLRequest {
             public private(set) var pokemon_v2_ability: pokemon_v2_ability? = nil
 
             public struct pokemon_v2_ability: Codable {
-                public init(__typename: String = String(), is_main_series: Bool = Bool(), name: String = String(), pokemon_v2_abilityflavortexts_aggregate: pokemon_v2_ability.pokemon_v2_abilityflavortext_aggregate = pokemon_v2_ability.pokemon_v2_abilityflavortext_aggregate()) {
+                public init(__typename: String = String(), is_main_series: Bool = Bool(), name: String = String(), other_name: String = String(), pokemon_v2_abilityflavortexts_aggregate: pokemon_v2_ability.pokemon_v2_abilityflavortext_aggregate = pokemon_v2_ability.pokemon_v2_abilityflavortext_aggregate()) {
                     self.__typename = __typename
                     self.is_main_series = is_main_series
                     self.name = name
+                    self.other_name = other_name
                     self.pokemon_v2_abilityflavortexts_aggregate = pokemon_v2_abilityflavortexts_aggregate
                 }
 
@@ -133,31 +135,33 @@ public struct ExamplePokemonQuery: AutoGraphQLRequest {
                     self.__typename = typename
                     self.is_main_series = try values.decode(Bool.self, forKey: .is_main_series)
                     self.name = try values.decode(String.self, forKey: .name)
+                    self.other_name = try values.decode(String.self, forKey: .other_name)
                     self.pokemon_v2_abilityflavortexts_aggregate = try values.decode(pokemon_v2_ability.pokemon_v2_abilityflavortext_aggregate.self, forKey: .pokemon_v2_abilityflavortexts_aggregate)
                 }
 
                 public private(set) var __typename: String = String()
                 public private(set) var is_main_series: Bool = Bool()
                 public private(set) var name: String = String()
+                public private(set) var other_name: String = String()
 
                 public private(set) var pokemon_v2_abilityflavortexts_aggregate: pokemon_v2_abilityflavortext_aggregate = pokemon_v2_abilityflavortext_aggregate()
 
                 public struct pokemon_v2_abilityflavortext_aggregate: Codable {
-                    public init(__typename: String = String(), aggregate: pokemon_v2_abilityflavortext_aggregate.pokemon_v2_abilityflavortext_aggregate_fields? = nil) {
+                    public init(__typename: String = String(), agg: pokemon_v2_abilityflavortext_aggregate.pokemon_v2_abilityflavortext_aggregate_fields? = nil) {
                         self.__typename = __typename
-                        self.aggregate = aggregate
+                        self.agg = agg
                     }
 
                     public init(from decoder: Decoder) throws {
                         let values = try decoder.container(keyedBy: CodingKeys.self)
                         let typename = try values.decode(String.self, forKey: .__typename)
                         self.__typename = typename
-                        self.aggregate = try values.decode(pokemon_v2_abilityflavortext_aggregate.pokemon_v2_abilityflavortext_aggregate_fields?.self, forKey: .aggregate)
+                        self.agg = try values.decode(pokemon_v2_abilityflavortext_aggregate.pokemon_v2_abilityflavortext_aggregate_fields?.self, forKey: .agg)
                     }
 
                     public private(set) var __typename: String = String()
 
-                    public private(set) var aggregate: pokemon_v2_abilityflavortext_aggregate_fields? = nil
+                    public private(set) var agg: pokemon_v2_abilityflavortext_aggregate_fields? = nil
 
                     public struct pokemon_v2_abilityflavortext_aggregate_fields: Codable {
                         public init(__typename: String = String(), count: Int = Int()) {

--- a/Tests/libAutoGraphCodeGenTests/Products/spacex-gql/SpaceXGQLSchema.swift
+++ b/Tests/libAutoGraphCodeGenTests/Products/spacex-gql/SpaceXGQLSchema.swift
@@ -289,13 +289,13 @@ public struct ExampleSpaceXQuery: AutoGraphQLRequest {
     public var operation: AutoGraphQL.Operation {
         return AutoGraphQL.Operation(type: .query, name: "ExampleSpaceX", variableDefinitions: nil, directives: nil, selectionSet: [
             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-            Selection.field(name: "company", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "company", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "ceo", alias: "", arguments: nil, directives: nil, type: .scalar)
+                Selection.field(name: "ceo", alias: nil, arguments: nil, directives: nil, type: .scalar)
             ])),
-            Selection.field(name: "roadster", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "roadster", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "apoapsis_au", alias: "", arguments: nil, directives: nil, type: .scalar)
+                Selection.field(name: "apoapsis_au", alias: nil, arguments: nil, directives: nil, type: .scalar)
             ]))
         ])
     }
@@ -375,17 +375,17 @@ public struct ExampleSpaceX2Query: AutoGraphQLRequest {
     public var operation: AutoGraphQL.Operation {
         return AutoGraphQL.Operation(type: .query, name: "ExampleSpaceX2", variableDefinitions: [try! AnyVariableDefinition(name: "limit", typeName: .scalar(.int), defaultValue: nil)], directives: nil, selectionSet: [
             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-            Selection.field(name: "company", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "company", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "ceo", alias: "", arguments: nil, directives: nil, type: .scalar)
+                Selection.field(name: "ceo", alias: nil, arguments: nil, directives: nil, type: .scalar)
             ])),
-            Selection.field(name: "capsules", alias: "", arguments: ["find" : ["id" : 4, "mission" : "cool", "type" : "rocket"] as [String: Any], "limit" : Variable(name: "limit")], directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "capsules", alias: nil, arguments: ["find" : ["id" : 4, "mission" : "cool", "type" : "rocket"] as [String: Any], "limit" : Variable(name: "limit")], directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "id", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "missions", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                Selection.field(name: "id", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "missions", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "name", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "flight", alias: "", arguments: nil, directives: nil, type: .scalar)
+                    Selection.field(name: "name", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "flight", alias: nil, arguments: nil, directives: nil, type: .scalar)
                 ]))
             ]))
         ])
@@ -491,14 +491,14 @@ public struct MutationMutation: AutoGraphQLRequest {
     public var operation: AutoGraphQL.Operation {
         return AutoGraphQL.Operation(type: .mutation, name: "Mutation", variableDefinitions: [try! AnyVariableDefinition(name: "where", typeName: .nonNull(.object(typeName: "users_bool_exp")), defaultValue: nil), try! AnyVariableDefinition(name: "set", typeName: .object(typeName: "users_set_input"), defaultValue: nil)], directives: nil, selectionSet: [
             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-            Selection.field(name: "update_users", alias: "", arguments: ["where" : Variable(name: "where"), "_set" : Variable(name: "set")], directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "update_users", alias: nil, arguments: ["where" : Variable(name: "where"), "_set" : Variable(name: "set")], directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "affected_rows", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "returning", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                Selection.field(name: "affected_rows", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "returning", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "rocket", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "timestamp", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "twitter", alias: "", arguments: nil, directives: nil, type: .scalar)
+                    Selection.field(name: "rocket", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "timestamp", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "twitter", alias: nil, arguments: nil, directives: nil, type: .scalar)
                 ]))
             ]))
         ])
@@ -592,12 +592,12 @@ public struct SubscriptionSubscription: AutoGraphQLRequest {
 
     public var operation: AutoGraphQL.Operation {
         return AutoGraphQL.Operation(type: .subscription, name: "Subscription", variableDefinitions: [try! AnyVariableDefinition(name: "limit", typeName: .scalar(.int), defaultValue: nil), try! AnyVariableDefinition(name: "offset", typeName: .scalar(.int), defaultValue: nil), try! AnyVariableDefinition(name: "distinctOn", typeName: .list(.nonNull(.object(typeName: "users_select_column"))), defaultValue: nil)], directives: nil, selectionSet: [
-            Selection.field(name: "users", alias: "", arguments: ["limit" : Variable(name: "limit"), "offset" : Variable(name: "offset"), "distinct_on" : Variable(name: "distinctOn")], directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "users", alias: nil, arguments: ["limit" : Variable(name: "limit"), "offset" : Variable(name: "offset"), "distinct_on" : Variable(name: "distinctOn")], directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "name", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "rocket", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "timestamp", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "id", alias: "", arguments: nil, directives: nil, type: .scalar)
+                Selection.field(name: "name", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "rocket", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "timestamp", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "id", alias: nil, arguments: nil, directives: nil, type: .scalar)
             ]))
         ])
     }

--- a/Tests/libAutoGraphCodeGenTests/Products/swapi-gql/SWAPIGQLSchema.swift
+++ b/Tests/libAutoGraphCodeGenTests/Products/swapi-gql/SWAPIGQLSchema.swift
@@ -28,9 +28,9 @@ public enum SWAPIGQLSchema {
         public static var fragments: [FragmentDefinition] {
             let fragment = FragmentDefinition(name: "CharacterConnFrag", type: "FilmCharactersConnection", directives: nil, selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "pageInfo", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                Selection.field(name: "pageInfo", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "hasPreviousPage", alias: "", arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "hasPreviousPage", alias: nil, arguments: nil, directives: nil, type: .scalar),
                     Selection.field(name: "hasPreviousPage", alias: "alias1", arguments: nil, directives: nil, type: .scalar)
                 ]))
             ])!
@@ -93,8 +93,8 @@ public enum SWAPIGQLSchema {
         public static var fragments: [FragmentDefinition] {
             let fragment = FragmentDefinition(name: "PersonFrag", type: "Person", directives: nil, selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "id", alias: "", arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "birthYear", alias: "", arguments: nil, directives: nil, type: .scalar)
+                Selection.field(name: "id", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "birthYear", alias: nil, arguments: nil, directives: nil, type: .scalar)
             ])!
 
             let fragments = [fragment]
@@ -146,70 +146,70 @@ public struct ExampleStarWarsQuery: AutoGraphQLRequest {
     public var operation: AutoGraphQL.Operation {
         return AutoGraphQL.Operation(type: .query, name: "ExampleStarWars", variableDefinitions: [try! AnyVariableDefinition(name: "nodeId", typeName: .nonNull(.scalar(.id)), defaultValue: nil), try! AnyVariableDefinition(name: "after", typeName: .scalar(.string), defaultValue: nil), try! AnyVariableDefinition(name: "first", typeName: .scalar(.int), defaultValue: nil), try! AnyVariableDefinition(name: "last", typeName: .scalar(.int), defaultValue: nil)], directives: nil, selectionSet: [
             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-            Selection.field(name: "node", alias: "", arguments: ["id" : Variable(name: "nodeId")], directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "node", alias: nil, arguments: ["id" : Variable(name: "nodeId")], directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "id", alias: "", arguments: nil, directives: nil, type: .scalar),
+                Selection.field(name: "id", alias: nil, arguments: nil, directives: nil, type: .scalar),
                 Selection.inlineFragment(namedType: "Film", directives: nil, selectionSet: [
                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "director", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "id", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "planetConnection", alias: "", arguments: ["first" : Variable(name: "first"), "last" : Variable(name: "last")], directives: nil, type: .object(selectionSet: [
+                    Selection.field(name: "director", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "id", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "planetConnection", alias: nil, arguments: ["first" : Variable(name: "first"), "last" : Variable(name: "last")], directives: nil, type: .object(selectionSet: [
                         Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                        Selection.field(name: "totalCount", alias: "", arguments: nil, directives: nil, type: .scalar)
+                        Selection.field(name: "totalCount", alias: nil, arguments: nil, directives: nil, type: .scalar)
                     ]))
                 ]),
                 Selection.inlineFragment(namedType: "Person", directives: nil, selectionSet: [
                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "birthYear", alias: "", arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "hairColor", alias: "", arguments: nil, directives: nil, type: .scalar)
+                    Selection.field(name: "birthYear", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                    Selection.field(name: "hairColor", alias: nil, arguments: nil, directives: nil, type: .scalar)
                 ])
             ])),
-            Selection.field(name: "allFilms", alias: "", arguments: ["after" : Variable(name: "after")], directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "allFilms", alias: nil, arguments: ["after" : Variable(name: "after")], directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                Selection.field(name: "edges", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                Selection.field(name: "edges", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                    Selection.field(name: "node", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                    Selection.field(name: "node", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                         Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
                         Selection.inlineFragment(namedType: "Film", directives: nil, selectionSet: [
                             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                            Selection.field(name: "episodeID", alias: "", arguments: nil, directives: nil, type: .scalar)
+                            Selection.field(name: "episodeID", alias: nil, arguments: nil, directives: nil, type: .scalar)
                         ]),
-                        Selection.field(name: "characterConnection", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                        Selection.field(name: "characterConnection", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
                             Selection.fragmentSpread(name: "CharacterConnFrag", directives: nil),
-                            Selection.field(name: "pageInfo", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                            Selection.field(name: "pageInfo", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "hasPreviousPage", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "startCursor", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "hasNextPage", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "endCursor", alias: "", arguments: nil, directives: nil, type: .scalar)
+                                Selection.field(name: "hasPreviousPage", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                Selection.field(name: "startCursor", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                Selection.field(name: "hasNextPage", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                Selection.field(name: "endCursor", alias: nil, arguments: nil, directives: nil, type: .scalar)
                             ])),
-                            Selection.field(name: "characters", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                            Selection.field(name: "characters", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "birthYear", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "created", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "edited", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "eyeColor", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                Selection.field(name: "homeworld", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                Selection.field(name: "birthYear", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                Selection.field(name: "created", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                Selection.field(name: "edited", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                Selection.field(name: "eyeColor", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                Selection.field(name: "homeworld", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                    Selection.field(name: "climates", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                    Selection.field(name: "filmConnection", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                    Selection.field(name: "climates", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                    Selection.field(name: "filmConnection", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                         Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                        Selection.field(name: "edges", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                        Selection.field(name: "edges", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                            Selection.field(name: "node", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                            Selection.field(name: "node", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                                Selection.field(name: "characterConnection", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                                Selection.field(name: "characterConnection", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                                    Selection.field(name: "characters", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                                    Selection.field(name: "characters", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                                         Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                                        Selection.field(name: "filmConnection", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                                        Selection.field(name: "filmConnection", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                                             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                                            Selection.field(name: "films", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                                            Selection.field(name: "films", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                                                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                                                Selection.field(name: "id", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                                                Selection.field(name: "episodeID", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                                                Selection.field(name: "openingCrawl", alias: "", arguments: nil, directives: nil, type: .scalar)
+                                                                Selection.field(name: "id", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                                                Selection.field(name: "episodeID", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                                                Selection.field(name: "openingCrawl", alias: nil, arguments: nil, directives: nil, type: .scalar)
                                                             ]))
                                                         ]))
                                                     ]))
@@ -218,14 +218,14 @@ public struct ExampleStarWarsQuery: AutoGraphQLRequest {
                                         ]))
                                     ]))
                                 ])),
-                                Selection.field(name: "vehicleConnection", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                Selection.field(name: "vehicleConnection", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                     Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                    Selection.field(name: "edges", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                    Selection.field(name: "edges", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                         Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                        Selection.field(name: "node", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+                                        Selection.field(name: "node", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                                             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-                                            Selection.field(name: "crew", alias: "", arguments: nil, directives: nil, type: .scalar),
-                                            Selection.field(name: "edited", alias: "", arguments: nil, directives: nil, type: .scalar)
+                                            Selection.field(name: "crew", alias: nil, arguments: nil, directives: nil, type: .scalar),
+                                            Selection.field(name: "edited", alias: nil, arguments: nil, directives: nil, type: .scalar)
                                         ]))
                                     ]))
                                 ]))
@@ -729,7 +729,7 @@ public struct TestTopLevelFragmentQuery: AutoGraphQLRequest {
     public var operation: AutoGraphQL.Operation {
         return AutoGraphQL.Operation(type: .query, name: "TestTopLevelFragment", variableDefinitions: nil, directives: nil, selectionSet: [
             Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
-            Selection.field(name: "person", alias: "", arguments: nil, directives: nil, type: .object(selectionSet: [
+            Selection.field(name: "person", alias: nil, arguments: nil, directives: nil, type: .object(selectionSet: [
                 Selection.field(name: "__typename", alias: nil, arguments: nil, directives: nil, type: .scalar),
                 Selection.fragmentSpread(name: "PersonFrag", directives: nil)
             ]))


### PR DESCRIPTION
bug caused by our switch from `Alias` being a separate type to `typealias Alias = Name`, yet `Alias?` and `Name?` have different semantics under query string generation.